### PR TITLE
Fixed handler bars compiler

### DIFF
--- a/app/templates/class/blah/test.hbs
+++ b/app/templates/class/blah/test.hbs
@@ -1,5 +1,0 @@
-<div>
-  {{#each content.files}}
-    {{name}}
-  {{/each}} 
-</div>

--- a/tools/compile-templates.js
+++ b/tools/compile-templates.js
@@ -20,7 +20,7 @@ var fs = require('fs'),
 
 
 function buildTemplate(name, content) {
-    return "define('" + name +"', ['exports'], function(__exports__){ __exports__['default'] = " + content + "; });";
+    return "define(\"" + name +"\", [\"exports\"], function(__exports__){ __exports__[\"default\"] = Ember.Handlebars.template(" + content + "); });";
 }
 
 function processFile(f) {
@@ -28,7 +28,7 @@ function processFile(f) {
     name = path.join(path.dirname(path.normalize(f)), path.basename(f, path.extname(f))),
     template;
 
-    template = compiler.precompile(body).toString();
+    template = compiler.precompile(body, true).toString();
 
     console.log(chalk.green('compiling: ' + f));
     return buildTemplate(name, template);


### PR DESCRIPTION
Needed to wrap the output of the compiler in `Ember.Handlebars.template()` - missed that step. 
