### PR TITLE
Added server and watch targets to launch the api-stub and nodemon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,12 @@ ci: dev
 lint:
 	$(JSHINT) .
 
+server:
+	node api-stub/server.js
+
+watch:
+	./node_modules/nodemon/bin/nodemon.js -w app -w spec -e hbs,js,less -x make dev 
+
 clean:
 	rm -rf _build
 


### PR DESCRIPTION
Adding the ability to launch the api-stub server and nodemon filewatch from the makefile. @copenhas can you review. You may have better strategy. My makefile skills aren't the best. Ideally It would be nice to trigger both from one target and be able to kill that when you are done such that both processes are brought down. Maybe we could write a script that does that, and call that script from like make server.
